### PR TITLE
add bead properties for velocity, KE, momentum, write out velocity to…

### DIFF
--- a/polybinderCG/__init__.py
+++ b/polybinderCG/__init__.py
@@ -3,3 +3,5 @@ from . import writers
 from .__version__ import __version__
 
 __all__ = ["__version__", "plotting", "writers"]
+
+from polybinderCG.coarse_grain import System

--- a/polybinderCG/coarse_grain.py
+++ b/polybinderCG/coarse_grain.py
@@ -394,6 +394,18 @@ class Structure:
         return sum(self.system.snap.particles.mass[self.atom_indices])
 
     @property
+    def velocity(self):
+        return sum(self.system.snap.particles.velocity[self.atom_indices])
+
+    @property
+    def momentum(self):
+        return self.velocity * self.mass
+    
+    @property
+    def kinetic_energy(self):
+        return 0.5 * self.mass * (self.velocity**2)
+
+    @property
     def center(self):
         """The (x,y,z) position of the center of the structure accounting
         for the periodic boundaries in the system.

--- a/polybinderCG/writers.py
+++ b/polybinderCG/writers.py
@@ -37,12 +37,14 @@ def write_snapshot(beads, rewrap=True, box_expand=None):
     dihedral_groups = []
     all_pos = []
     masses = []
+    velocities = []
     box = beads[0].system.box 
 
     for idx, bead in enumerate(beads):
         all_types.append(bead.name)
         all_pos.append(bead.unwrapped_center)
         masses.append(bead.mass)
+        velocities.append(bead.velocity)
 
         try:
             # Add bond type and group indices
@@ -103,6 +105,7 @@ def write_snapshot(beads, rewrap=True, box_expand=None):
     s.particles.typeid = np.array(type_ids) 
     s.particles.position = w_positions 
     s.particles.mass = masses
+    s.particles.velocity = velocities
     s.particles.image = w_images
     #Bonds
     s.bonds.N = len(all_pairs)


### PR DESCRIPTION
This PR adds bead properties for velocity, kinetic energy, and momentum. The gsd write now writes out the bead velocities to `snap.particles.velocity`